### PR TITLE
refactor(sales): move business logic to model and fix pdf import

### DIFF
--- a/sale_order/views.py
+++ b/sale_order/views.py
@@ -7,7 +7,7 @@ from companies.mixins import CompanyObjectMixin
 from outflows.models import Outflow
 from django.http import HttpResponse
 from django.core.exceptions import PermissionDenied
-from sales.utils.pdf import generate_order_pdf
+from sales.utils.pdf import generate_invoice_pdf
 from sales import forms
 from sales.models import Sale
 
@@ -30,7 +30,7 @@ class OrderPDFView(LoginRequiredMixin, PermissionRequiredMixin, CompanyObjectMix
 
     def get(self, request, *args, **kwargs):
         order = self.get_object()
-        pdf = generate_order_pdf(order)
+        pdf = generate_invoice_pdf(order)
         response = HttpResponse(pdf, content_type="application/pdf")
         response["Context-Disposition"] = f'attachment; filename="pedido_venda_{order.id}.pdf"'
         return response


### PR DESCRIPTION
- Refactor SaleCreateView to use 'Fat Model' pattern
- Move total calculation and discount logic to Sale model
- Implement transaction.atomic() for data integrity
- Fix ImportError in sale_order views (renamed generate_order_pdf)

## 🚀 Descrição

_Esta PR aborda duas frentes principais: a resolução de um bug crítico de inicialização e uma refatoração arquitetural no fluxo de criação de vendas (SaleCreateView).

1. Correção de Bug (Critical):

Corrigido um ImportError em sale_order/views.py. A aplicação falhava ao iniciar pois tentava importar generate_order_pdf, que não existia. A referência foi atualizada para a função correta: generate_invoice_pdf.

2. Refatoração (Fat Model, Thin View):

Remoção de Lógica da View: A SaleCreateView estava sobrecarregada com regras de negócio (cálculo de subtotais, aplicação de descontos, controle de fluxo).

Centralização no Model: Criado o método update_totals() e finalize() no model Sale. Agora o Model é responsável por garantir a consistência dos seus próprios dados matemáticos.

Integridade de Dados (ACID): Implementado transaction.atomic() no método form_valid. Isso garante que a Venda, os Itens e a Baixa de Estoque sejam tratados como uma unidade atômica. Se um falhar, nada é salvo, prevenindo registros "órfãos" no banco de dados._


## 📝 Tipo de Alteração

- [X] 🐞 Correção de bug (alteração ininterrupta que corrige um problema)
- [ ] ✨ Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [ ] 💥 Alteração que quebra a compatibilidade (correção ou recurso que faria com que a funcionalidade existente não funcionasse como esperado)
- [X] ♻️ Refatoração (nenhuma mudança de funcionalidade, apenas melhoria de código)
- [ ] 📚 Documentação (apenas mudanças na documentação)
- [ ] ⚙️ Outros (configuração de CI, build, etc.)


## ✅ Checklist do Pull Request

- [X] Meu código segue o guia de estilo deste projeto (o `flake8` e `pre-commit` passam).
- [ ] Eu adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona.
- [ ] Testes de unidade novos e existentes passam localmente com minhas alterações.
- [ ] A documentação foi atualizada, se necessário.
- [X] Eu revisei meu próprio código para garantir que não há erros óbvios.


## 📸 Screenshots (se aplicável)

_.(N/A - Alterações puramente de Backend e Lógica de Negócio)_
